### PR TITLE
fix: :bug: Fix Add-on Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ In order to facilitate running the project entirely on the system where Home Ass
 
 You can use this button to automatically download and build the addon for `oobabooga/text-generation-webui`
 
-[![Open your Home Assistant instance and show the dashboard of an add-on.](https://my.home-assistant.io/badges/supervisor_addon.svg)](https://my.home-assistant.io/redirect/supervisor_addon/?addon=2ad5febb_text-generation-webui&repository_url=https%3A%2F%2Fgithub.com%2Facon96%2Fhome-llm)
+[![Open your Home Assistant instance and show the dashboard of an add-on.](https://my.home-assistant.io/badges/supervisor_addon.svg)](https://my.home-assistant.io/redirect/supervisor_addon/?addon=f459db47_text-generation-webui&repository_url=https%3A%2F%2Fgithub.com%2Facon96%2Fhome-llm)
 
 If the automatic installation fails then you can install the addon manually using the following steps:
 


### PR DESCRIPTION
Fix Add-On Link
It appears that since I generated the link using the fork I created to send the pull request, the hex code at the beginning of the link was different. I updated it, now that the project can be added to the add-on store, to get the right one.