### PR TITLE
feat: added support for object "chat.completion"

### DIFF
--- a/custom_components/llama_conversation/__init__.py
+++ b/custom_components/llama_conversation/__init__.py
@@ -387,7 +387,10 @@ class LLaMAAgent(AbstractConversationAgent):
         if choices[0]["finish_reason"] != "stop":
             _LOGGER.warn("Model response did not end on a stop token (unfinished sentence)")
 
-        return choices[0]["text"]
+        if result.json()["object"] == "chat.completion":
+            return choices[0]["message"]["content"]
+        else:
+            return choices[0]["text"]
     
     def _load_local_model(self):
         if not self.model_path:


### PR DESCRIPTION
Hi, I'm working on a video about using this integration with liteLLM + ollama (since the integration is now compatible with the OpenAI API), but the integration fails, because liteLLM returns a chat.completion object instead of text_completion for the /completions API

LocalAI text_completion:
```
{
    "created": 1705555351,
    "object": "text_completion",
    "id": "276d0e22-fdb8-41f8-b3f7-a540efd8bdbb",
    "model": "home-3b",
    "choices": [
        {
            "index": 0,
            "finish_reason": "stop",
            "text": "The acronym llm stands for \"Laughing Out Loud\".\n"
        }
    ],
    "usage": {
        "prompt_tokens": 0,
        "completion_tokens": 0,
        "total_tokens": 0
    }
}
```

liteLLM chat.completion:
```
{
    "created": 1705555351,
    "object": "chat.completion",
    "id": "0f00e14d-5e9e-4762-b770-2cb78f2d3634",
    "model": "ollama/home-3b",
    "choices": [
        {
            "index": 0,
            "finish_reason": "stop",
            "message": {
                "role": "assistant",
                "content": "The acronym llm stands for \"Laughing Out Loud\".\n"
            }
        }
    ],
   "usage": {
        "prompt_tokens": 39,
        "completion_tokens": 65,
        "total_tokens": 104
    }
}
```

I know that this sounds more like a problem for the liteLLM team, but since it is possible to identify the object type, I thought that it might be worth it to add the option so de integration knows where to look if it receives a chat.completion object, without impacting normal usage. This change will make the integration compatible with liteLLM and all the liteLLM supported Providers (https://docs.litellm.ai/docs/providers) Included Ollama.

And on that note, to facilitate the configuration of the models, Ollama includes a [Library](https://ollama.ai/library), it is possible to [create an entry](https://github.com/jmorganca/ollama/blob/main/docs/import.md) for the Home_3B model.
I created one myself for [V1](https://ollama.ai/fixt/home-3b-v1), since V2 is not yet compatible with Ollama (it hangs). But I think it should be under your account, not mine. I don't want to burden you with more tasks, so at least I thought to let you know.