### PR TITLE
feat: Ollama API Support

### DIFF
--- a/custom_components/llama_conversation/__init__.py
+++ b/custom_components/llama_conversation/__init__.py
@@ -115,6 +115,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             agent_cls = TextGenerationWebuiAgent
         elif backend_type == BACKEND_TYPE_LLAMA_CPP_PYTHON_SERVER:
             agent_cls = LlamaCppPythonAPIAgent
+        elif backend_type == BACKEND_TYPE_OLLAMA:
+            agent_cls = OllamaAPIAgent
         
         return agent_cls(hass, entry)
 
@@ -684,3 +686,88 @@ class LlamaCppPythonAPIAgent(GenericOpenAIAPIAgent):
             request_params["grammar"] = self.grammar
 
         return endpoint, request_params
+
+class OllamaAPIAgent(LLaMAAgent):
+    api_host: str
+    api_key: str
+    model_name: str
+
+    def _load_model(self, entry: ConfigEntry) -> None:
+        # TODO: https
+        self.api_host = f"http://{entry.data[CONF_HOST]}:{entry.data[CONF_PORT]}"
+        self.api_key = entry.data.get(CONF_OPENAI_API_KEY)
+        self.model_name = entry.data.get(CONF_CHAT_MODEL)
+
+
+    def _chat_completion_params(self, conversation: dict) -> (str, dict):
+        request_params = {}
+
+        endpoint = "/api/chat"
+        request_params["messages"] = [ { "role": x["role"], "content": x["message"] } for x in conversation ]
+
+        return endpoint, request_params
+
+    def _completion_params(self, conversation: dict) -> (str, dict):
+        request_params = {}
+
+        endpoint = "/api/generate"
+        request_params["prompt"] = self._format_prompt(conversation)
+
+        return endpoint, request_params
+    
+    def _extract_response(self, response_json: dict) -> str:        
+        if response_json["done"] != "true":
+            _LOGGER.warn("Model response did not end on a stop token (unfinished sentence)")
+
+        if "response" in response_json:
+            return response_json["response"]
+        else:
+            return response_json["message"]["content"]
+    
+    def _generate(self, conversation: dict) -> str:
+        max_tokens = self.entry.options.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS)
+        temperature = self.entry.options.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE)
+        top_p = self.entry.options.get(CONF_TOP_P, DEFAULT_TOP_P)
+        timeout = self.entry.options.get(CONF_REQUEST_TIMEOUT, DEFAULT_REQUEST_TIMEOUT)
+        use_chat_api = self.entry.options.get(CONF_REMOTE_USE_CHAT_ENDPOINT, DEFAULT_REMOTE_USE_CHAT_ENDPOINT)
+        
+
+        request_params = {
+            "model": self.model_name,
+            "stream": False,
+            "options": {
+                "top_p": top_p,
+                "temperature": temperature,
+                "num_ctx": max_tokens,
+            }   
+        }
+        
+        if use_chat_api:
+            endpoint, additional_params = self._chat_completion_params(conversation)
+        else:
+            endpoint, additional_params = self._completion_params(conversation)
+        
+        request_params.update(additional_params)
+
+        headers = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        result = requests.post(
+            f"{self.api_host}{endpoint}", 
+            json=request_params,
+            timeout=timeout,
+            headers=headers,
+        )
+
+        try:
+            result.raise_for_status()
+        except requests.RequestException as err:
+            _LOGGER.debug(f"Err was: {err}")
+            _LOGGER.debug(f"Request was: {request_params}")
+            _LOGGER.debug(f"Result was: {result.text}")
+            return f"Failed to communicate with the API! {err}"
+        
+        _LOGGER.debug(result.json())
+
+        return self._extract_response(result.json())

--- a/custom_components/llama_conversation/config_flow.py
+++ b/custom_components/llama_conversation/config_flow.py
@@ -112,7 +112,7 @@ def STEP_INIT_DATA_SCHEMA(backend_type=None):
                     BACKEND_TYPE_TEXT_GEN_WEBUI,
                     BACKEND_TYPE_GENERIC_OPENAI,
                     BACKEND_TYPE_LLAMA_CPP_PYTHON_SERVER,
-                    # BACKEND_TYPE_OLLAMA
+                    BACKEND_TYPE_OLLAMA
                 ],
                 translation_key=CONF_BACKEND_TYPE,
                 multiple=False,
@@ -727,6 +727,29 @@ def local_llama_config_option_schema(options: MappingProxyType[str, Any], backen
                 description={"suggested_value": options.get(CONF_USE_GBNF_GRAMMAR)},
                 default=DEFAULT_USE_GBNF_GRAMMAR,
             ): bool
+        })
+    elif backend_type == BACKEND_TYPE_OLLAMA:
+        result = insert_after_key(result, CONF_MAX_TOKENS, {
+            vol.Required(
+                CONF_REQUEST_TIMEOUT,
+                description={"suggested_value": options.get(CONF_REQUEST_TIMEOUT)},
+                default=DEFAULT_REQUEST_TIMEOUT,
+            ): int,
+            vol.Required(
+                CONF_REMOTE_USE_CHAT_ENDPOINT,
+                description={"suggested_value": options.get(CONF_REMOTE_USE_CHAT_ENDPOINT)},
+                default=DEFAULT_REMOTE_USE_CHAT_ENDPOINT,
+            ): bool,
+            vol.Required(
+                CONF_TEMPERATURE,
+                description={"suggested_value": options.get(CONF_TEMPERATURE)},
+                default=DEFAULT_TEMPERATURE,
+            ): NumberSelector(NumberSelectorConfig(min=0, max=1, step=0.05)),
+            vol.Required(
+                CONF_TOP_P,
+                description={"suggested_value": options.get(CONF_TOP_P)},
+                default=DEFAULT_TOP_P,
+            ): NumberSelector(NumberSelectorConfig(min=0, max=1, step=0.05)),
         })
 
     return result

--- a/custom_components/llama_conversation/translations/en.json
+++ b/custom_components/llama_conversation/translations/en.json
@@ -43,7 +43,7 @@
                     "download_model_from_hf": "Download model from HuggingFace",
                     "use_local_backend": "Use Llama.cpp"
                 },
-                "description": "Select the backend for running the model. The options are:\n1. Llama.cpp with a model from HuggingFace\n2. Llama.cpp with a model stored on the disk\n3. [text-generation-webui API](https://github.com/oobabooga/text-generation-webui)\n4. Generic OpenAI API Compatible API\n5. [llama-cpp-python Server](https://llama-cpp-python.readthedocs.io/en/latest/server/)\n\nIf using Llama.cpp locally, make sure you copied the correct wheel file to the same directory as the integration.",
+                "description": "Select the backend for running the model. The options are:\n1. Llama.cpp with a model from HuggingFace\n2. Llama.cpp with a model stored on the disk\n3. [text-generation-webui API](https://github.com/oobabooga/text-generation-webui)\n4. Generic OpenAI API Compatible API\n5. [llama-cpp-python Server](https://llama-cpp-python.readthedocs.io/en/latest/server/)\n6. [Ollama API](https://github.com/jmorganca/ollama/blob/main/docs/api.md)\n\nIf using Llama.cpp locally, make sure you copied the correct wheel file to the same directory as the integration.",
                 "title": "Select Backend"
             }
         }
@@ -89,7 +89,7 @@
                 "text-generation-webui_api": "text-generation-webui API",
                 "generic_openai": "Generic OpenAI Compatible API",
                 "llama_cpp_python_server": "llama-cpp-python Server",
-                "ollama": "Ollama"
+                "ollama": "Ollama API"
 
             }
         },


### PR DESCRIPTION
Hey, I saw that you had done a refactor to simplify the process of adding new backends, so I decided to complete the Ollama API implementation.
Please have a look at the code, I might have missed some details, the implementation is working so far, for both Generate and Chat API.
I would like to ask you if it is possible to add an option for Ollama Web UI, it adds a security layer over the Ollama API, so the user can use an API Key for access (I checked the syntaxis is the same as the one used for any other API KEY, so the code is already there). But the API changes:
/api/chat --> /ollama/api/chat
/api/generate --> /ollama/api/generate

With a toggle option, we could change the endpoints programmatically.