### PR TITLE
Small fixes to brightness adjustment and EOS token removal

### DIFF
--- a/custom_components/llama_conversation/__init__.py
+++ b/custom_components/llama_conversation/__init__.py
@@ -345,7 +345,7 @@ class LLaMAAgent(AbstractConversationAgent):
 
                 # fix certain arguments
                 # make sure brightness is 0-255 and not a percentage
-                if "brightness" in extra_arguments and 0.0 < extra_arguments["brightness"] < 1.0:
+                if "brightness" in extra_arguments and 0.0 < extra_arguments["brightness"] <= 1.0:
                     extra_arguments["brightness"] = int(extra_arguments["brightness"] * 255)
 
                 # convert string "tuple" to a list for RGB colors

--- a/custom_components/llama_conversation/__init__.py
+++ b/custom_components/llama_conversation/__init__.py
@@ -235,6 +235,8 @@ class LLaMAAgent(AbstractConversationAgent):
         """Process a sentence."""
 
         raw_prompt = self.entry.options.get(CONF_PROMPT, DEFAULT_PROMPT)
+        prompt_template = self.entry.options.get(CONF_PROMPT_TEMPLATE, DEFAULT_PROMPT_TEMPLATE)
+        template_desc = PROMPT_TEMPLATE_DESCRIPTIONS[prompt_template]
         refresh_system_prompt = self.entry.options.get(CONF_REFRESH_SYSTEM_PROMPT, DEFAULT_REFRESH_SYSTEM_PROMPT)
         remember_conversation = self.entry.options.get(CONF_REMEMBER_CONVERSATION, DEFAULT_REMEMBER_CONVERSATION)
         remember_num_interactions = self.entry.options.get(CONF_REMEMBER_NUM_INTERACTIONS, False)
@@ -374,7 +376,7 @@ class LLaMAAgent(AbstractConversationAgent):
                         to_say += f"\nFailed to run: {line}"
                         _LOGGER.exception(f"Failed to run: {line}")
 
-        to_say = to_say.replace("<|im_end|>", "") # remove the eos token if it is returned (some backends + the old model does this)
+        to_say = to_say.replace(template_desc["assistant"]["suffix"], "") # remove the eos token if it is returned (some backends + the old model does this)
         
         intent_response = intent.IntentResponse(language=user_input.language)
         intent_response.async_set_speech(to_say)


### PR DESCRIPTION
- Currently, brightness cannot not be adjusted to 100% due to the value being interpreted as 1/255 (minimum brightness). This includes 1.0 in the conditional statement that converts a brightness percentage to an 8-bit value, so the model can specify 100% brightness correctly.
- The current implementation of EOS token removal uses a hardcoded ChatML EOS token. This finds the EOS token from the assistant section of the user's configured prompt format.