### PR TITLE
Fix bug in Chat Completions API

### DIFF
--- a/custom_components/llama_conversation/agent.py
+++ b/custom_components/llama_conversation/agent.py
@@ -856,7 +856,7 @@ class GenericOpenAIAPIAgent(LLaMAAgent):
         if choices[0]["finish_reason"] != "stop":
             _LOGGER.warning("Model response did not end on a stop token (unfinished sentence)")
 
-        if response_json["object"] == "chat.completion":
+        if response_json["object"] in ["chat.completion", "chat.completion.chunk"]:
             return choices[0]["message"]["content"]
         else:
             return choices[0]["text"]


### PR DESCRIPTION
Recent versions of LocalAI return the object type `chat.completion.chunk` as well as `chat.completion`.
The component only checks for `chat.completion`.
This result in the following exception:
```Traceback (most recent call last):                                                                                                                                                                                        
   File "/config/custom_components/llama_conversation/agent.py", line 262, in async_process                                                                                                                                
     response = await self._async_generate(conversation)                                                                                                                                                                   
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                   
   File "/config/custom_components/llama_conversation/agent.py", line 187, in _async_generate
     return await self.hass.async_add_executor_job(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 58, in run
     result = self.fn(*self.args, **self.kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/config/custom_components/llama_conversation/agent.py", line 907, in _generate
     return self._extract_response(result.json())
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/config/custom_components/llama_conversation/agent.py", line 862, in _extract_response
     return choices[0]["text"]
            ~~~~~~~~~~^^^^^^^^
 KeyError: 'text'
```


This PR introduces a check for `chat.completion.chunk` as well.