### PR TITLE
Various fixes for the custom integration

### DIFF
--- a/custom_components/llama_conversation/agent.py
+++ b/custom_components/llama_conversation/agent.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import aiohttp
+import asyncio
 import csv
 import importlib
 import json
@@ -1181,6 +1182,7 @@ class GenericOpenAIAPIAgent(LocalLLMAgent):
             headers["Authorization"] = f"Bearer {self.api_key}"
 
         session = async_get_clientsession(self.hass)
+        response = None
         try:
             async with session.post(
                 f"{self.api_host}{endpoint}",
@@ -1190,7 +1192,7 @@ class GenericOpenAIAPIAgent(LocalLLMAgent):
             ) as response:
                 response.raise_for_status()
                 result = await response.json()
-        except aiohttp.ClientTimeout:
+        except asyncio.TimeoutError:
             return "The generation request timed out! Please check your connection settings, increase the timeout in settings, or decrease the number of exposed entities."
         except aiohttp.ClientError as err:
             _LOGGER.debug(f"Err was: {err}")
@@ -1446,6 +1448,7 @@ class OllamaAPIAgent(LocalLLMAgent):
             headers["Authorization"] = f"Bearer {self.api_key}"
         
         session = async_get_clientsession(self.hass)
+        response = None
         try:
             async with session.post(
                 f"{self.api_host}{endpoint}",
@@ -1455,7 +1458,7 @@ class OllamaAPIAgent(LocalLLMAgent):
             ) as response:
                 response.raise_for_status()
                 result = await response.json()
-        except aiohttp.ClientTimeout:
+        except asyncio.TimeoutError:
             return "The generation request timed out! Please check your connection settings, increase the timeout in settings, or decrease the number of exposed entities."
         except aiohttp.ClientError as err:
             _LOGGER.debug(f"Err was: {err}")

--- a/custom_components/llama_conversation/agent.py
+++ b/custom_components/llama_conversation/agent.py
@@ -489,8 +489,9 @@ class LocalLLMAgent(AbstractConversationAgent):
             
             if area_id:
                 area = area_registry.async_get_area(entity.area_id)
-                attributes["area_id"] = area.id
-                attributes["area_name"] = area.name
+                if area:
+                    attributes["area_id"] = area.id
+                    attributes["area_name"] = area.name
             
             entity_states[state.entity_id] = attributes
             domains.add(state.domain)

--- a/custom_components/llama_conversation/agent.py
+++ b/custom_components/llama_conversation/agent.py
@@ -1130,7 +1130,7 @@ class GenericOpenAIAPIAgent(LocalLLMAgent):
         request_params = {}
         api_base_path = self.entry.options.get(CONF_GENERIC_OPENAI_PATH, DEFAULT_GENERIC_OPENAI_PATH)
 
-        endpoint = f"{api_base_path}/chat/completions"
+        endpoint = f"/{api_base_path}/chat/completions"
         request_params["messages"] = [ { "role": x["role"], "content": x["message"] } for x in conversation ]
 
         return endpoint, request_params


### PR DESCRIPTION
Some things prevented me from being able to use the integration properly. I follow debug logs and exceptions back to the code and fixed stuff until it worked.

Here are summary of changes:
- There was a missing slash in the Generic OpenAI backend's Chat Completions endpoint. Looks like it was just missed so i added it the same as the Completions endpoint.
- Code was catching `aiohttp.ClientTimeout` as an exception when trying the POST requests, but that is for configuring timeouts and doesn't inherit from an exception base class. I imported `asyncio` and used `asyncio.ClientTimeout` as per the documentation.
  - Also, for this once exception was caught and was not from timeout, response was sometimes unbound too, so I bound it before the request so logging didn't throw exception for unbound variable.
- Sometimes the function for getting the area from an area ID returns None. I added check for this, so area is only added if it really exists. Not sure why this happens, probably something to do with munted HA configuration but this way is more robust at least.

Not sure how much of this follows your style or pragmatic code preferences, let me know if you want anything changed!