### PR TITLE
fix(utils): Update closest_color logic to use the exported properties and methods from webcolors library

### DIFF
--- a/custom_components/llama_conversation/utils.py
+++ b/custom_components/llama_conversation/utils.py
@@ -6,6 +6,7 @@ import logging
 import multiprocessing
 import voluptuous as vol
 import webcolors
+from webcolors import CSS3
 from importlib.metadata import version
 
 from homeassistant.helpers import config_validation as cv
@@ -21,6 +22,12 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+CSS3_NAME_TO_RGB = {
+    name: webcolors.name_to_rgb(name, CSS3)
+    for name
+    in webcolors.names(CSS3)
+}
+
 class MissingQuantizationException(Exception):
     def __init__(self, missing_quant: str, available_quants: list[str]):
         self.missing_quant = missing_quant
@@ -28,8 +35,9 @@ class MissingQuantizationException(Exception):
 
 def closest_color(requested_color):
     min_colors = {}
-    for key, name in webcolors.CSS3_HEX_TO_NAMES.items():
-        r_c, g_c, b_c = webcolors.hex_to_rgb(key)
+    
+    for name, rgb in CSS3_NAME_TO_RGB.items():
+        r_c, g_c, b_c = rgb
         rd = (r_c - requested_color[0]) ** 2
         gd = (g_c - requested_color[1]) ** 2
         bd = (b_c - requested_color[2]) ** 2


### PR DESCRIPTION
You can see here, what is exported by the webcolors library:
https://github.com/ubernostrum/webcolors/blob/trunk/src/webcolors/__init__.py

It would be possible to import the _CSS_NAMES_TO_HEX dictionary via: 

```python
from webcolors._definitions import _CSS3_NAMES_TO_HEX
```

However, this is against best practices as the library author intended for these to be considered private.

I used the `names` and `name_to_rgb` methods, which are exported by the library to replicate the same functionality.

Fixes Issue #211