### PR TITLE
fix: Initialize the `tool_response`

### DIFF
--- a/custom_components/llama_conversation/conversation.py
+++ b/custom_components/llama_conversation/conversation.py
@@ -421,6 +421,7 @@ class LocalLLMAgent(ConversationEntity, AbstractConversationAgent):
                 response=intent_response, conversation_id=conversation_id
             )
 
+        tool_response = None
         # parse response
         to_say = service_call_pattern.sub("", response.strip())
         for block in service_call_pattern.findall(response.strip()):


### PR DESCRIPTION
The `tool_response` variable is initialized within the for loop which iterates over the function calls returned by the LLM. However this variable is referenced outside this loop if certain configuration options are set. This means if the LLM does not call a tool function, but the config is set up as multi-turn, you get an error.

FIxes issue: #186