### PR TITLE
AttributeError: module 'webcolors' has no attribute 'CSS3_HEX_TO_NAMES'

### DIFF
--- a/custom_components/llama_conversation/__init__.py
+++ b/custom_components/llama_conversation/__init__.py
@@ -71,7 +71,6 @@ class HassServiceTool(llm.Tool):
     parameters = vol.Schema({
         vol.Required('service'): str,
         vol.Required('target_device'): str,
-        vol.Optional('rgb_color'): str,
         vol.Optional('brightness'): float,
         vol.Optional('temperature'): float,
         vol.Optional('humidity'): float,


### PR DESCRIPTION
This change proposes to remove the rgb_color as it causes issues in home assistant os.

`AttributeError: module 'webcolors' has no attribute 'CSS3_HEX_TO_NAMES'`