### PR TITLE
Removing async_migrate_engine For HomeAssistant Breaking Change

### DIFF
--- a/custom_components/llama_conversation/conversation.py
+++ b/custom_components/llama_conversation/conversation.py
@@ -227,9 +227,6 @@ class LocalLLMAgent(ConversationEntity, AbstractConversationAgent):
     async def async_added_to_hass(self) -> None:
         """When entity is added to Home Assistant."""
         await super().async_added_to_hass()
-        assist_pipeline.async_migrate_engine(
-            self.hass, "conversation", self.entry.entry_id, self.entity_id
-        )
         conversation.async_set_agent(self.hass, self.entry, self)
 
     async def async_will_remove_from_hass(self) -> None:


### PR DESCRIPTION
In a July update, the HA core integrated this PR: https://github.com/home-assistant/core/pull/147968, which drops the `assist_pipeline` migration code. The suggested fix in the `ollama` integration from that thread appears to just be to delete the relevant lines, which is what I've done here.