### PR TITLE
Handle empty finish_reason

### DIFF
--- a/custom_components/llama_conversation/backends/generic_openai.py
+++ b/custom_components/llama_conversation/backends/generic_openai.py
@@ -217,8 +217,9 @@ class GenericOpenAIAPIClient(LocalLLMClient):
             response_text = choice["text"]
             streamed = False
 
-        if not streamed or streamed and choice["finish_reason"]:
-            if choice["finish_reason"] == "length" or choice["finish_reason"] == "content_filter":
+        if not streamed or (streamed and choice.get("finish_reason")):
+            finish_reason = choice.get("finish_reason")
+            if finish_reason in ("length", "content_filter"):
                 _LOGGER.warning("Model response did not end on a stop token (unfinished sentence)")
 
         return response_text, tool_calls


### PR DESCRIPTION
Some backends do not return finish_reason parameters in the response. This leads to KeyError with the following traceback:

`Traceback (most recent call last):
  File "/config/custom_components/llama_conversation/entity.py", line 271, in _async_handle_message
    message = await anext(generation_result)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/conversation/chat_log.py", line 344, in async_add_delta_content_stream
    async for delta in stream:
    ...<91 lines>...
            )
  File "/config/custom_components/llama_conversation/entity.py", line 189, in async_iterator
    async for input_chunk in result:
    ...<4 lines>...
        )
  File "/config/custom_components/llama_conversation/entity.py", line 372, in _async_parse_completion
    async for chunk in token_generator:
    ...<72 lines>...
            yield result
  File "/config/custom_components/llama_conversation/backends/generic_openai.py", line 178, in anext_token
    to_say, tool_calls = self._extract_response(json.loads(chunk), llm_api, user_input)
                         ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/llama_conversation/backends/generic_openai.py", line 220, in _extract_response
    if not streamed or streamed and choice["finish_reason"]:`
    
    
  This PR fixes it to gracefully handle cases when finish_reason is not present in response.