### PR TITLE
Use OpenAI Python Lib instead of using aiohttp for OpenAI compatible API

### DIFF
--- a/custom_components/llama_conversation/backends/generic_openai.py
+++ b/custom_components/llama_conversation/backends/generic_openai.py
@@ -137,7 +137,7 @@ class GenericOpenAIAPIClient(LocalLLMClient):
                             if event.type == "content.delta": # normal text chunks we can yield
                                 yield event.delta, None
                             elif event.type == "tool_calls.function.arguments.done": # function calls need to wait until complete to be yielded
-                                yield None, [{"function": event.to_dict()}]
+                                yield None, [{"function": {"name": event.name, "arguments": event.parsed_arguments}}]
             except asyncio.TimeoutError as err:
                 raise HomeAssistantError("The generation request timed out! Please check your connection settings, increase the timeout in settings, or decrease the number of exposed entities.") from err
             except OpenAIError as err:

--- a/custom_components/llama_conversation/backends/generic_openai.py
+++ b/custom_components/llama_conversation/backends/generic_openai.py
@@ -137,7 +137,7 @@ class GenericOpenAIAPIClient(LocalLLMClient):
                             if event.type == "content.delta": # normal text chunks we can yield
                                 yield event.delta, None
                             elif event.type == "tool_calls.function.arguments.done": # function calls need to wait until complete to be yielded
-                                yield None, [event.to_dict()]
+                                yield None, [{"function": event.to_dict()}]
             except asyncio.TimeoutError as err:
                 raise HomeAssistantError("The generation request timed out! Please check your connection settings, increase the timeout in settings, or decrease the number of exposed entities.") from err
             except OpenAIError as err:

--- a/custom_components/llama_conversation/manifest.json
+++ b/custom_components/llama_conversation/manifest.json
@@ -12,6 +12,7 @@
   "requirements": [
       "huggingface-hub>=0.23.0",
       "webcolors>=24.8.0",
-      "ollama>=0.5.1"
+      "ollama>=0.5.1",
+      "openai==2.14.0"
   ]
 }

--- a/custom_components/requirements.txt
+++ b/custom_components/requirements.txt
@@ -1,3 +1,4 @@
 huggingface-hub>=0.23.0
 webcolors>=24.8.0
 ollama>=0.5.1
+openai==2.14.0


### PR DESCRIPTION
To properly support streaming tool calls ([https://github.com/ggml-org/llama.cpp/pull/12379](https://github.com/ggml-org/llama.cpp/pull/12379)) and to improve overall code cleanliness, I propose migrating to the official OpenAI Python library ([https://pypi.org/project/openai/](https://pypi.org/project/openai/)) instead of using `aiohttp` directly for OpenAI-compatible endpoints.

I tested my changes with llamacpp b7549, functiongemma (original and my custom finetune) and the `LlamaCppServerClient`:

```bash
llamacpp/llama-b7549/llama-server --host 0.0.0.0 -c 32000 -m llama_models/functiongemma-270m-it-q8_0.gguf --port 8090
```

as well as vllm v0.13.0, Qwen3 30bA3b and the `LlamaCppServerClient`:

```bash
podman run --device nvidia.com/gpu=all \
        -v ~/.cache/huggingface:/root/.cache/huggingface \
        -v ~/ai/vllm/models:/root/models \
        -p 8000:8000 \
        --ipc=host \
        docker.io/vllm/vllm-openai:v0.13.0    \
        --download-dir /root/models/ \
        --model /root/models/Qwen3-30B-A3B-Instruct-2507-AWQ-4bit/ \
        --enable-auto-tool-choice \
        --tool-call-parser hermes \
        --gpu-memory-utilization 0.95 \
        --max-num-seqs 128 \
        --dtype auto \
        --swap-space 16 \
        --trust-remote-code \
        --host 0.0.0.0 \
        --port 8000
```

both with their native tool calling.
Since I do not have an OpenAI account, I cannot validate the functionality against their api.
This pull request should fix compatibility with functiongemma (on lamacpp at least) as well.

A potential follow-up would be to migrate `GenericOpenAIResponsesAPIClient` to the OpenAI library as well. However, since I am not really familiar with the Responses API, I left it as is for now.