### PR TITLE
Fix tool call parsing for OpenAI-compatible APIs that return unwrapped function format

### DIFF
--- a/custom_components/llama_conversation/entity.py
+++ b/custom_components/llama_conversation/entity.py
@@ -294,8 +294,12 @@ class LocalLLMClient:
                             # try multiple dict key names
                             function_content = raw_tool_call.get("function") or raw_tool_call.get("function_call") or raw_tool_call.get("tool")
                             if not function_content:
-                                _LOGGER.warning("Received tool call dict without 'function', 'function_call' or 'tool' key: %s", raw_tool_call)
-                                continue
+                                # Check if the dict itself is the function content (has 'name' and 'arguments')
+                                if "name" in raw_tool_call:
+                                    function_content = raw_tool_call
+                                else:
+                                    _LOGGER.warning("Received tool call dict without 'function', 'function_call' or 'tool' key: %s", raw_tool_call)
+                                    continue
                             tool_call, to_say = parse_raw_tool_call(function_content, agent_id)
 
                         if tool_call:
@@ -361,8 +365,12 @@ class LocalLLMClient:
                         # try multiple dict key names
                         function_content = raw_tool_call.get("function") or raw_tool_call.get("function_call") or raw_tool_call.get("tool")
                         if not function_content:
-                            _LOGGER.warning("Received tool call dict without 'function', 'function_call' or 'tool' key: %s", raw_tool_call)
-                            continue
+                            # Check if the dict itself is the function content (has 'name' and 'arguments')
+                            if "name" in raw_tool_call:
+                                function_content = raw_tool_call
+                            else:
+                                _LOGGER.warning("Received tool call dict without 'function', 'function_call' or 'tool' key: %s", raw_tool_call)
+                                continue
                         tool_call, to_say = parse_raw_tool_call(function_content, agent_id)
                     if tool_call:
                         _LOGGER.debug("Tool call parsed: %s", tool_call)


### PR DESCRIPTION
## Problem
When using OpenAI-compatible API backends (such as proxy servers that translate between different LLM provider formats), tool calls may be returned in a simplified format where the function details (name and arguments) are at the top level of the tool call object, rather than nested under a function, function_call, or tool key.
For example, some proxies return:
{name: HassTurnOn, arguments: {"name": "Kitchen Light"}}
Instead of the expected:
{function: {name: HassTurnOn, arguments: {"name": "Kitchen Light"}}}
This caused tool calls to be silently ignored with the warning:
Received tool call dict without 'function', 'function_call' or 'tool' key

## Solution
Added a fallback check in both streaming and non-streaming tool call parsers. When the standard wrapper keys (function, function_call, tool) are not found, the code now checks if the dict itself contains a name key, indicating it's already in the unwrapped function format, and uses it directly.
## Impact
- Improves compatibility with a wider range of OpenAI-compatible API providers and proxy servers
- No breaking changes to existing functionality
- Tool calls in both wrapped and unwrapped formats are now handled correctly

I can give more details if needed
Resolves #349 