### PR TITLE
Fix TTS streaming: forward supports_streaming from backend clients to conversation agent

### DIFF
--- a/custom_components/llama_conversation/backends/ollama.py
+++ b/custom_components/llama_conversation/backends/ollama.py
@@ -72,6 +72,7 @@ def _build_default_ssl_context() -> ssl.SSLContext:
     return context
 
 class OllamaAPIClient(LocalLLMClient):
+    _attr_supports_streaming = True
     api_host: str
     api_key: Optional[str]
 

--- a/custom_components/llama_conversation/conversation.py
+++ b/custom_components/llama_conversation/conversation.py
@@ -81,6 +81,11 @@ class LocalLLMAgent(ConversationEntity, AbstractConversationAgent, LocalLLMEntit
         """Return a list of supported languages."""
         return MATCH_ALL
 
+    @property
+    def supports_streaming(self) -> bool:
+        """Forward streaming support from the backend client."""
+        return getattr(self.client, '_attr_supports_streaming', False)
+
     async def async_process(
         self, user_input: ConversationInput
     ) -> ConversationResult:

--- a/tests/llama_conversation/test_basic.py
+++ b/tests/llama_conversation/test_basic.py
@@ -103,3 +103,13 @@ def test_normalize_path_helper():
     assert _normalize_path("") == ""
     assert _normalize_path("/v1/") == "/v1"
     assert _normalize_path("v2") == "/v2"
+
+
+def test_ollama_client_supports_streaming():
+    """OllamaAPIClient must declare streaming support like the other backends."""
+    assert getattr(OllamaAPIClient, '_attr_supports_streaming', False) is True
+
+
+def test_generic_openai_client_supports_streaming():
+    """GenericOpenAIAPIClient must declare streaming support."""
+    assert getattr(GenericOpenAIAPIClient, '_attr_supports_streaming', False) is True

--- a/tests/llama_conversation/test_conversation_agent.py
+++ b/tests/llama_conversation/test_conversation_agent.py
@@ -112,3 +112,33 @@ async def test_async_process_generates_response(monkeypatch, hass):
     # System prompt should be rendered once when message history is empty.
     assert client.generated_prompts == [DEFAULT_PROMPT]
     assert agent.supported_languages == MATCH_ALL
+
+
+def test_agent_supports_streaming_forwards_from_client(hass):
+    """Agent must forward supports_streaming from its backend client."""
+    client = DummyClient(hass)
+    subentry = DummySubentry()
+    entry = DummyEntry(subentry=subentry, runtime_data=client)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry
+
+    agent = LocalLLMAgent(hass, entry, subentry, client)
+
+    # Client without the flag => agent should report False
+    assert agent.supports_streaming is False
+
+    # Client with the flag set True => agent should forward it
+    client._attr_supports_streaming = True
+    assert agent.supports_streaming is True
+
+
+def test_agent_supports_streaming_false_by_default(hass):
+    """Agent should default to no streaming when client lacks the attribute."""
+    client = DummyClient(hass)
+    subentry = DummySubentry()
+    entry = DummyEntry(subentry=subentry, runtime_data=client)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry
+
+    agent = LocalLLMAgent(hass, entry, subentry, client)
+
+    # DummyClient has no _attr_supports_streaming => should be False
+    assert agent.supports_streaming is False


### PR DESCRIPTION
## Problem

Home Assistant's voice pipeline checks `agent.supports_streaming` on the `ConversationEntity` to decide whether to stream TTS audio. Currently this is always `false` for home-llm, even though the backends actually support streaming generation.

This causes the pipeline to set `stream_response: false`, meaning users hear nothing until the full LLM response is generated AND fully synthesized.

## Root Cause

Two issues:

1. **`OllamaAPIClient`** implements `_generate_stream()` with `stream=True` but never sets `_attr_supports_streaming = True`. The `GenericOpenAIAPIClient` and `LlamaCppClient` backends both set this flag correctly — Ollama was missed.

2. **`LocalLLMAgent`** (the `ConversationEntity` that HA's pipeline actually checks) inherits `_attr_supports_streaming = False` from HA's base `ConversationEntity` class and never overrides it with the backend client's value. This means even backends that correctly declare streaming support (OpenAI, llama.cpp) don't actually get TTS streaming in the voice pipeline.

## Fix

- Add `_attr_supports_streaming = True` to `OllamaAPIClient`
- Add a `supports_streaming` property to `LocalLLMAgent` that forwards the flag from the backend client

## Testing

Before fix: Pipeline trace shows `stream_response: false`, TTS waits for complete LLM response.
After fix: Pipeline trace should show `stream_response: true`, TTS begins as first sentence completes.

Tested with Ollama backend + Mistral Small 3.2 + wyoming-openai (Kokoro) TTS on HA 2026.2.