### PR TITLE
Fix TTS streaming: include role in first streaming delta

### DIFF
--- a/custom_components/llama_conversation/entity.py
+++ b/custom_components/llama_conversation/entity.py
@@ -179,6 +179,7 @@ class LocalLLMClient:
         chat_log: conversation.chat_log.ChatLog
     ):
         async def async_iterator():
+            first = True
             async for input_chunk in result:
                 _LOGGER.debug("Received chunk: %s", input_chunk)
 
@@ -186,10 +187,14 @@ class LocalLLMClient:
                 if tool_calls and not chat_log.llm_api:
                     raise HomeAssistantError("Model attempted to call a tool but no LLM API was provided")
 
-                yield conversation.AssistantContentDeltaDict(
+                delta = conversation.AssistantContentDeltaDict(
                     content=input_chunk.response,
-                    tool_calls=tool_calls 
+                    tool_calls=tool_calls
                 )
+                if first:
+                    delta["role"] = "assistant"
+                    first = False
+                yield delta
         
         return chat_log.async_add_delta_content_stream(agent_id, stream=async_iterator())
         

--- a/tests/llama_conversation/test_entity.py
+++ b/tests/llama_conversation/test_entity.py
@@ -5,7 +5,7 @@ import json
 import pytest
 from json import JSONDecodeError
 
-from custom_components.llama_conversation.entity import LocalLLMClient
+from custom_components.llama_conversation.entity import LocalLLMClient, TextGenerationResult
 from custom_components.llama_conversation.const import (
     CONF_EXTRA_ATTRIBUTES_TO_EXPOSE,
     CONF_USE_IN_CONTEXT_LEARNING_EXAMPLES,
@@ -160,3 +160,36 @@ async def test_generate_system_prompt_renders(monkeypatch, client, hass):
 
     assert isinstance(rendered, str)
     assert "light.kitchen" in rendered
+
+
+@pytest.mark.asyncio
+async def test_transform_result_stream_first_delta_has_role(client):
+    """First streaming delta must include role='assistant' so HA's TTS pipeline starts."""
+
+    async def mock_stream():
+        yield TextGenerationResult(response="Hello", response_streamed=True)
+        yield TextGenerationResult(response=" world", response_streamed=True)
+        yield TextGenerationResult(response="!", response_streamed=True)
+
+    captured_stream = None
+
+    class MockChatLog:
+        llm_api = None
+
+        def async_add_delta_content_stream(self, agent_id, stream):
+            nonlocal captured_stream
+            captured_stream = stream
+
+    await client._transform_result_stream(
+        mock_stream(), "test-agent", MockChatLog()
+    )
+
+    deltas = [delta async for delta in captured_stream]
+
+    assert len(deltas) == 3
+    # First delta must carry the role so the pipeline starts feeding TTS.
+    assert deltas[0]["role"] == "assistant"
+    assert deltas[0]["content"] == "Hello"
+    # Subsequent deltas must NOT include role (matches HA built-in agent protocol).
+    assert "role" not in deltas[1]
+    assert "role" not in deltas[2]


### PR DESCRIPTION
## Summary

- **Symptom**: TTS is silent for the full generation duration despite `stream_response: true` being enabled. Users hear nothing until the entire response completes, then get the full audio at once.
- **Root cause**: home-llm's `_transform_result_stream` never includes `role` in any streaming delta. HA's voice pipeline (`assist_pipeline/pipeline.py` ~line 1133) tracks `chat_log_role` and discards all deltas until it sees one with `role: "assistant"`. Without it, the 60-character streaming threshold is never reached, `tts_start_streaming` never fires, and TTS falls back to non-streaming mode.
- **Fix**: Add a `first = True` flag in the inner `async_iterator()` of `_transform_result_stream`. The first yielded `AssistantContentDeltaDict` now includes `role: "assistant"`. Subsequent deltas omit the role key, matching the protocol used by HA's built-in agents (e.g., `ollama/entity.py` ~line 159-161).

## How HA's built-in agents handle this

HA's Ollama integration (`homeassistant/components/ollama/entity.py`) sets `chunk["role"] = "assistant"` on the very first yielded delta. This signals to the pipeline that assistant content has begun, enabling the TTS streaming queue to start accepting text.

## Relationship to PR #352

This PR is a companion to PR #352, which fixes the `supports_streaming` flag so HA knows to use streaming in the first place. **Both PRs are needed for end-to-end streaming TTS**:

1. PR #352: Makes HA request streaming from home-llm (fixes `supports_streaming` property)
2. This PR: Makes the streamed deltas usable by HA's TTS pipeline (adds `role` to first delta)

## Test plan

- [x] Added test `test_transform_result_stream_first_delta_has_role` that mocks 3 `TextGenerationResult` chunks, calls `_transform_result_stream`, and asserts the first delta has `role == "assistant"` while subsequent deltas do not have a `role` key