### PR TITLE
Fix system prompt not injected when refresh_system_prompt is disabled

### DIFF
--- a/custom_components/llama_conversation/conversation.py
+++ b/custom_components/llama_conversation/conversation.py
@@ -129,7 +129,10 @@ class LocalLLMAgent(ConversationEntity, AbstractConversationAgent, LocalLLMEntit
                 new_message_history.extend(message_history[1:][-(remember_num_interactions * 2):])
 
             # re-generate prompt if necessary
-            if len(message_history) == 0 or refresh_system_prompt:
+            has_system_prompt = any(
+                isinstance(msg, conversation.SystemContent) for msg in message_history
+            )
+            if not has_system_prompt or refresh_system_prompt:
                 try:
                     system_prompt = conversation.SystemContent(content=self.client._generate_system_prompt(raw_prompt, llm_api, self.runtime_options))
                 except TemplateError as err:
@@ -143,10 +146,10 @@ class LocalLLMAgent(ConversationEntity, AbstractConversationAgent, LocalLLMEntit
                         response=intent_response, conversation_id=user_input.conversation_id
                     )
 
-                if len(message_history) == 0:
-                    message_history.append(system_prompt)
-                else:
+                if message_history and isinstance(message_history[0], conversation.SystemContent):
                     message_history[0] = system_prompt
+                else:
+                    message_history.insert(0, system_prompt)
 
             tool_calls: List[Tuple[llm.ToolInput, Any]] = []
             # if max tool calls is 0 then we expect to generate the response & tool call in one go

--- a/tests/llama_conversation/test_conversation_agent.py
+++ b/tests/llama_conversation/test_conversation_agent.py
@@ -154,58 +154,47 @@ def _make_agent(hass, subentry_data_overrides=None):
 
 
 @pytest.mark.asyncio
-async def test_system_prompt_generated_when_chat_log_has_user_content(monkeypatch, hass):
-    """System prompt must be generated on the first turn even when chat_log
-    already contains a UserContent (added by HA before async_process runs)
-    and refresh_system_prompt is False."""
+@pytest.mark.parametrize(
+    "refresh, initial_content, expect_generated, expect_first_content",
+    [
+        pytest.param(
+            False,
+            [UserContent(content="turn on the lights")],
+            1,
+            "rendered-system-prompt",
+            id="first_turn_no_system_prompt",
+        ),
+        pytest.param(
+            True,
+            [SystemContent(content="old-system-prompt"), UserContent(content="turn on the lights")],
+            1,
+            "rendered-system-prompt",
+            id="refresh_replaces_existing",
+        ),
+        pytest.param(
+            False,
+            [SystemContent(content="existing-system-prompt"), UserContent(content="turn on the lights")],
+            0,
+            "existing-system-prompt",
+            id="no_refresh_keeps_existing",
+        ),
+    ],
+)
+async def test_system_prompt_injection(
+    monkeypatch, hass, refresh, initial_content, expect_generated, expect_first_content,
+):
+    """Verify system prompt generation/replacement based on refresh setting
+    and whether a SystemContent already exists in chat history."""
     agent, client = _make_agent(hass, {
-        CONF_REFRESH_SYSTEM_PROMPT: False, CONF_REMEMBER_CONVERSATION: True,
+        CONF_REFRESH_SYSTEM_PROMPT: refresh, CONF_REMEMBER_CONVERSATION: True,
     })
     chat_log = FakeChatLog()
-    chat_log.content.append(UserContent(content="turn on the lights"))
+    chat_log.content.extend(initial_content)
     _patch_chat(monkeypatch, chat_log)
 
     result = await agent.async_process(_make_user_input())
 
     assert result.response.speech["plain"]["speech"] == "hello from llm"
-    assert len(client.generated_prompts) == 1
+    assert len(client.generated_prompts) == expect_generated
     assert isinstance(chat_log.content[0], SystemContent)
-
-
-@pytest.mark.asyncio
-async def test_system_prompt_regenerated_when_refresh_enabled(monkeypatch, hass):
-    """When refresh_system_prompt is True, the system prompt should be
-    regenerated even if one already exists in the history."""
-    agent, client = _make_agent(hass, {
-        CONF_REFRESH_SYSTEM_PROMPT: True, CONF_REMEMBER_CONVERSATION: True,
-    })
-    chat_log = FakeChatLog()
-    chat_log.content.append(SystemContent(content="old-system-prompt"))
-    chat_log.content.append(UserContent(content="turn on the lights"))
-    _patch_chat(monkeypatch, chat_log)
-
-    result = await agent.async_process(_make_user_input())
-
-    assert result.response.speech["plain"]["speech"] == "hello from llm"
-    assert len(client.generated_prompts) == 1
-    assert client.generated_prompts[0] == DEFAULT_PROMPT
-
-
-@pytest.mark.asyncio
-async def test_system_prompt_not_regenerated_when_refresh_disabled(monkeypatch, hass):
-    """When refresh_system_prompt is False and a SystemContent already exists,
-    the system prompt should NOT be regenerated."""
-    agent, client = _make_agent(hass, {
-        CONF_REFRESH_SYSTEM_PROMPT: False, CONF_REMEMBER_CONVERSATION: True,
-    })
-    chat_log = FakeChatLog()
-    chat_log.content.append(SystemContent(content="existing-system-prompt"))
-    chat_log.content.append(UserContent(content="turn on the lights"))
-    _patch_chat(monkeypatch, chat_log)
-
-    result = await agent.async_process(_make_user_input())
-
-    assert result.response.speech["plain"]["speech"] == "hello from llm"
-    assert len(client.generated_prompts) == 0
-    assert isinstance(chat_log.content[0], SystemContent)
-    assert chat_log.content[0].content == "existing-system-prompt"
+    assert chat_log.content[0].content == expect_first_content

--- a/tests/llama_conversation/test_conversation_agent.py
+++ b/tests/llama_conversation/test_conversation_agent.py
@@ -3,13 +3,15 @@
 import pytest
 from contextlib import contextmanager
 
-from homeassistant.components.conversation import ConversationInput, SystemContent, AssistantContent
+from homeassistant.components.conversation import ConversationInput, SystemContent, AssistantContent, UserContent
 from homeassistant.const import MATCH_ALL
 
 from custom_components.llama_conversation.conversation import LocalLLMAgent
 from custom_components.llama_conversation.const import (
     CONF_CHAT_MODEL,
     CONF_PROMPT,
+    CONF_REFRESH_SYSTEM_PROMPT,
+    CONF_REMEMBER_CONVERSATION,
     DEFAULT_PROMPT,
     DOMAIN,
 )
@@ -112,3 +114,98 @@ async def test_async_process_generates_response(monkeypatch, hass):
     # System prompt should be rendered once when message history is empty.
     assert client.generated_prompts == [DEFAULT_PROMPT]
     assert agent.supported_languages == MATCH_ALL
+
+
+def _make_user_input(text="turn on the lights"):
+    return ConversationInput(
+        text=text, context=None, conversation_id="conv-id",
+        device_id=None, language="en", agent_id="agent-1",
+    )
+
+
+def _patch_chat(monkeypatch, chat_log):
+    """Patch chat_session and chat_log context managers for agent tests."""
+    @contextmanager
+    def fake_chat_session(_hass, _conversation_id):
+        yield FakeChatSession()
+
+    @contextmanager
+    def fake_chat_log_cm(_hass, _session, _user_input):
+        yield chat_log
+
+    monkeypatch.setattr(
+        "custom_components.llama_conversation.conversation.chat_session.async_get_chat_session",
+        fake_chat_session,
+    )
+    monkeypatch.setattr(
+        "custom_components.llama_conversation.conversation.conversation.async_get_chat_log",
+        fake_chat_log_cm,
+    )
+
+
+def _make_agent(hass, subentry_data_overrides=None):
+    client = DummyClient(hass)
+    subentry = DummySubentry()
+    if subentry_data_overrides:
+        subentry.data = {**subentry.data, **subentry_data_overrides}
+    entry = DummyEntry(subentry=subentry, runtime_data=client)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry
+    return LocalLLMAgent(hass, entry, subentry, client), client
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_generated_when_chat_log_has_user_content(monkeypatch, hass):
+    """System prompt must be generated on the first turn even when chat_log
+    already contains a UserContent (added by HA before async_process runs)
+    and refresh_system_prompt is False."""
+    agent, client = _make_agent(hass, {
+        CONF_REFRESH_SYSTEM_PROMPT: False, CONF_REMEMBER_CONVERSATION: True,
+    })
+    chat_log = FakeChatLog()
+    chat_log.content.append(UserContent(content="turn on the lights"))
+    _patch_chat(monkeypatch, chat_log)
+
+    result = await agent.async_process(_make_user_input())
+
+    assert result.response.speech["plain"]["speech"] == "hello from llm"
+    assert len(client.generated_prompts) == 1
+    assert isinstance(chat_log.content[0], SystemContent)
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_regenerated_when_refresh_enabled(monkeypatch, hass):
+    """When refresh_system_prompt is True, the system prompt should be
+    regenerated even if one already exists in the history."""
+    agent, client = _make_agent(hass, {
+        CONF_REFRESH_SYSTEM_PROMPT: True, CONF_REMEMBER_CONVERSATION: True,
+    })
+    chat_log = FakeChatLog()
+    chat_log.content.append(SystemContent(content="old-system-prompt"))
+    chat_log.content.append(UserContent(content="turn on the lights"))
+    _patch_chat(monkeypatch, chat_log)
+
+    result = await agent.async_process(_make_user_input())
+
+    assert result.response.speech["plain"]["speech"] == "hello from llm"
+    assert len(client.generated_prompts) == 1
+    assert client.generated_prompts[0] == DEFAULT_PROMPT
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_not_regenerated_when_refresh_disabled(monkeypatch, hass):
+    """When refresh_system_prompt is False and a SystemContent already exists,
+    the system prompt should NOT be regenerated."""
+    agent, client = _make_agent(hass, {
+        CONF_REFRESH_SYSTEM_PROMPT: False, CONF_REMEMBER_CONVERSATION: True,
+    })
+    chat_log = FakeChatLog()
+    chat_log.content.append(SystemContent(content="existing-system-prompt"))
+    chat_log.content.append(UserContent(content="turn on the lights"))
+    _patch_chat(monkeypatch, chat_log)
+
+    result = await agent.async_process(_make_user_input())
+
+    assert result.response.speech["plain"]["speech"] == "hello from llm"
+    assert len(client.generated_prompts) == 0
+    assert isinstance(chat_log.content[0], SystemContent)
+    assert chat_log.content[0].content == "existing-system-prompt"


### PR DESCRIPTION
## Summary

- **Symptom**: The model receives no system prompt at all — no persona, no device list, no instructions. The user's configured prompt template is silently ignored on every turn, leading to nonsensical answers.
- **Root cause**: HA's conversation pipeline adds a `UserContent` message to `chat_log.content` before `async_process` runs. So `message_history` is never empty — it always contains at least `[UserContent("user's message")]`. When `refresh_system_prompt` is `False`, the condition `len(message_history) == 0 or refresh_system_prompt` is always `False`, and the system prompt is never generated.
- **Fix**: Check for the presence of a `SystemContent` message in the history instead of checking list emptiness. Also fix the insert/replace logic to handle `message_history[0]` being a `UserContent` (insert at position 0) rather than blindly overwriting index 0.

## Test plan

- [x] Test that system prompt IS generated on first turn when `chat_log.content` already contains a `UserContent` and `refresh_system_prompt` is `False`
- [x] Test that system prompt IS regenerated when `refresh_system_prompt` is `True`
- [x] Test that system prompt is NOT regenerated on subsequent turns when `refresh_system_prompt` is `False` and a `SystemContent` already exists