### PR TITLE
Fix #1: Add support for qwen tool call format

### DIFF
--- a/custom_components/llama_conversation/entity.py
+++ b/custom_components/llama_conversation/entity.py
@@ -296,11 +296,25 @@ class LocalLLMClient:
                             tool_call, to_say = parse_raw_tool_call(raw_tool_call, agent_id)
                         else:
                             # try multiple dict key names
-                            function_content = raw_tool_call.get("function") or raw_tool_call.get("function_call") or raw_tool_call.get("tool")
+                            function_content = raw_tool_call.get("function") or raw_tool_call.get("function_call") or raw_tool_call.get("tool") or raw_tool_call.get("tool_calls")
                             if not function_content:
-                                # Check if the dict itself is the function content (has 'name' and 'arguments')
+                                # Check for qwen-style tool call format
+                                # qwen may return {'name': 'func_name', 'arguments': {...}} directly
+                                # or {'arguments': '{"name": "...", ...}'} where arguments is a JSON string
                                 if "name" in raw_tool_call:
                                     function_content = raw_tool_call
+                                elif "arguments" in raw_tool_call:
+                                    # Handle case where arguments is a malformed JSON string containing name
+                                    arguments = raw_tool_call["arguments"]
+                                    if isinstance(arguments, str):
+                                        # Try to extract name from malformed JSON like '{"name": "Office Light Switch"'
+                                        name_match = re.search(r'"name"\s*:\s*"([^"]+)"', arguments)
+                                        if name_match:
+                                            function_content = {"name": name_match.group(1), "arguments": {}}
+                                        else:
+                                            function_content = {"name": raw_tool_call.get("name", "unknown"), "arguments": {}}
+                                    else:
+                                        function_content = raw_tool_call
                                 else:
                                     _LOGGER.warning("Received tool call dict without 'function', 'function_call' or 'tool' key: %s", raw_tool_call)
                                     continue

--- a/custom_components/llama_conversation/entity.py
+++ b/custom_components/llama_conversation/entity.py
@@ -301,23 +301,23 @@ class LocalLLMClient:
                                 # Check for qwen-style tool call format
                                 # qwen may return {'name': 'func_name', 'arguments': {...}} directly
                                 # or {'arguments': '{"name": "...", ...}'} where arguments is a JSON string
-                                if "name" in raw_tool_call:
-                                    function_content = raw_tool_call
-                                elif "arguments" in raw_tool_call:
-                                    # Handle case where arguments is a malformed JSON string containing name
-                                    arguments = raw_tool_call["arguments"]
-                                    if isinstance(arguments, str):
-                                        # Try to extract name from malformed JSON like '{"name": "Office Light Switch"'
-                                        name_match = re.search(r'"name"\s*:\s*"([^"]+)"', arguments)
-                                        if name_match:
-                                            function_content = {"name": name_match.group(1), "arguments": {}}
-                                        else:
-                                            function_content = {"name": raw_tool_call.get("name", "unknown"), "arguments": {}}
-                                    else:
+                                match raw_tool_call:
+                                    case {"name": name}:
                                         function_content = raw_tool_call
-                                else:
-                                    _LOGGER.warning("Received tool call dict without 'function', 'function_call' or 'tool' key: %s", raw_tool_call)
-                                    continue
+                                    case {"arguments": arguments}:
+                                        # Handle case where arguments is a malformed JSON string containing name
+                                        if isinstance(arguments, str):
+                                            # Try to extract name from malformed JSON like '{"name": "Office Light Switch"'
+                                            name_match = re.search(r'"name"\s*:\s*"([^"]+)"', arguments)
+                                            if name_match:
+                                                function_content = {"name": name_match.group(1), "arguments": {}}
+                                            else:
+                                                function_content = {"name": raw_tool_call.get("name", "unknown"), "arguments": {}}
+                                        else:
+                                            function_content = raw_tool_call
+                                    case _:
+                                        _LOGGER.warning("Received tool call dict without 'function', 'function_call' or 'tool' key: %s", raw_tool_call)
+                                        continue
                             tool_call, to_say = parse_raw_tool_call(function_content, agent_id)
 
                         if tool_call:


### PR DESCRIPTION
This PR adds support for qwen-style tool call formats that are not properly handled by the current implementation.

## Changes made

- Handle qwen-style tool call dicts with 'name' and 'arguments' keys directly
- Support malformed JSON strings in the arguments field (e.g., '{"name": "Office Light Switch"')
- Extract tool name from malformed JSON when arguments contain the name
- Add 'tool_calls' as an additional key to check for function content

## Problem

When using OpenAI-compatible backends with the qwen3.5 model, the model returns tool calls in formats like:
- 
-  (malformed JSON)

The previous code only checked for 'function', 'function_call', or 'tool' keys, causing warnings and failed tool calls.

## Solution

The fix adds handling for these alternative formats by:
1. Checking if the dict has 'name' and 'arguments' keys directly (qwen format)
2. Extracting the tool name from malformed JSON strings in the arguments field
3. Creating a properly formatted tool call from the extracted information

Closes #1