### PR TITLE
Guard against non-string alias values in formatted_devices iteration

### DIFF
--- a/custom_components/llama_conversation/entity.py
+++ b/custom_components/llama_conversation/entity.py
@@ -592,6 +592,8 @@ class LocalLLMClient:
             })
             if "aliases" in attributes:
                 for alias in attributes["aliases"]:
+                    if not isinstance(alias, str):
+                        continue
                     formatted_devices = formatted_devices + f"{name} '{alias}' = {str_attributes}\n"
                     devices.append({
                         "entity_id": name,


### PR DESCRIPTION
## Problem

In `entity.py`, the alias-iteration loop inside `_generate_system_prompt` 
assumes `attributes["aliases"]` contains only strings. In practice, on at 
least some HA installs, this iterable can contain non-string sentinel values 
from Home Assistant Core internals (specifically `ComputedNameType._singleton` 
instances).

When the loop hits one of these, the existing f-string interpolation:

```python
formatted_devices = formatted_devices + f"{name} '{alias}' = {str_attributes}\n"
```

renders the sentinel's `__repr__` (the literal text `ComputedNameType._singleton`) 
into the system prompt. Each occurrence inflates the prompt context with garbage 
that the model has to parse, with no useful information conveyed.

## Impact

Measured on a production HA install running home-llm v0.4.7 with the Home-3B-v3 
Q8_0 model:

- **79 occurrences** of `ComputedNameType._singleton` leaked into the system 
  prompt per query
- **System prompt size: 10,856 → 5,461 chars** (~50% reduction) after applying 
  the guard
- Captured via wire-level debug logging on the Ollama-side request body

For 3B-class models with 4K context budgets, this is significant — half the 
prompt was sentinel-text noise.

## Fix

Two-line `isinstance` guard before the alias is used:

```diff
              if "aliases" in attributes:
                  for alias in attributes["aliases"]:
+                     if not isinstance(alias, str):
+                         continue
                      formatted_devices = formatted_devices + f"{name} '{alias}' = {str_attributes}\n"
```

The guard skips non-string entries entirely rather than coercing via `str()`. 
Coercion would risk treating sentinel `__repr__` values as legitimate aliases 
in downstream code paths.

## HA Core API note

`entity.aliases` is typed as `set[str]` per HA's entity registry API surface. 
The fact that Core internally emits non-string sentinels through this set is 
arguably a Core-side bug — but defensive guarding at the consumer (this 
integration) is the right pattern for downstream code that can't rely on 
upstream type contracts holding strictly in practice.

## Repro

1. Install home-llm v0.4.7 (or current `develop`)
2. Configure a subentry with `llm_hass_api: ['assist']` and entities exposed to Assist
3. Enable debug logging in Ollama (or your inference backend) to capture raw 
   request bodies
4. Send any conversation query; grep the captured system prompt for 
   `ComputedNameType._singleton`

On affected installs, the literal sentinel text appears once per exposed entity 
whose aliases include the Core-internal default name representation.

## Testing

Patch verified on the install where the bug was originally identified:
- Pre-patch: 79 sentinel occurrences in system prompt
- Post-patch: 0 occurrences
- Prompt size reduced ~50%
- No regressions on entity recognition or tool-call dispatch

The patched build has been running in production for ~9 days as of this PR.

## Diff note

GitHub's PR view shows 1 extra deletion + addition in `def supported_languages` 
due to web-editor trailing-whitespace stripping on an adjacent line. Verified 
whitespace-only via `?w=1`. The substantive change is the 2-line `isinstance` 
guard in `_generate_system_prompt`.