### PR TITLE
docs+entity: warn and document when ICL is enabled but prompt template lacks {{ response_examples }}

### DIFF
--- a/custom_components/llama_conversation/entity.py
+++ b/custom_components/llama_conversation/entity.py
@@ -626,6 +626,13 @@ class LocalLLMClient:
         if self.in_context_examples and llm_api:
             num_examples = int(entity_options.get(CONF_NUM_IN_CONTEXT_EXAMPLES, DEFAULT_NUM_IN_CONTEXT_EXAMPLES))
             render_variables["response_examples"] = self._generate_icl_examples(num_examples, list(entities_to_expose.keys()))
+            if "response_examples" not in prompt_template:
+                _LOGGER.warning(
+                    "in_context_examples is enabled and examples were loaded, but the configured prompt template "
+                    "does not reference {{ response_examples }} — ICL examples will be silently ignored. "
+                    "Customize the prompt template to include a {% for item in response_examples %}…{% endfor %} block, "
+                    "or disable in_context_examples!"
+                )
 
         return template.Template(prompt_template, self.hass).async_render(
             render_variables,

--- a/docs/Model Prompting.md
+++ b/docs/Model Prompting.md
@@ -97,6 +97,17 @@ Prompt Variables:
 
 The examples used for the `response_examples` variable are loaded from the `in_context_examples.csv` file in the `/custom_components/llama_conversation/` folder. For different language add extra suffix to name of this file eg. for polish responses set `in_context_examples_pl.csv` (note: currently only polish language is supported).
 
+### When `{{ response_examples }}` is rendered
+
+The ICL toggle (`Enable in context learning (ICL) examples`) loads examples from the CSV file and makes them available to the prompt renderer, **but they only reach the model if your prompt template references `{{ response_examples }}`**. If the template does not contain that marker, the toggle has no effect and the loaded examples are discarded silently.
+
+The `Home-LLM (v1-v3)` preset and other Home-* model presets default to the `DEFAULT_PROMPT_BASE_LEGACY` template, which renders `{{ formatted_devices }}` but does not reference `{{ response_examples }}`. With those presets, enabling the ICL toggle alone will not inject examples — you must either:
+
+1. Customize the prompt template to append the ICL block (the `{% for item in response_examples %}…{% endfor %}` loop from `ICL_EXTRAS` in `const.py`), or
+2. Switch to a non-legacy preset whose template includes the ICL block by default (e.g. the `qwen3`, `llama-3`, `mistral`, `mixtral`, `zephyr`, `phi-3`, or `command-r` presets).
+
+Starting in this version, the integration emits a `WARNING`-level log line when ICL is enabled and examples are loaded but the configured prompt template does not contain the `response_examples` marker — check the Home Assistant logs if your ICL configuration appears to have no effect.
+
 ### Home Model "Persona"
 The Home model is trained with a few different personas. They can be activated by using their system prompt found below:
 
@@ -125,7 +136,7 @@ Du bist „Al“, ein hilfreicher KI-Assistent, der die Geräte in einem Haus st
 
 **French**:
 ```
-Vous êtes « Al », un assistant IA utile qui contrôle les appareils d'une maison. Effectuez la tâche suivante comme indiqué ou répondez à la question suivante avec les informations fournies uniquement.
+Vous êtes « Al », un assistant IA utile qui contrôle les appareils d'une maison. Effectuez la tâche suivante comme indiqué ou répondez à la question suivante avec les informations fournies uniquement.
 ```
 
 **Spanish**:


### PR DESCRIPTION
## Problem

The `Enable in context learning (ICL) examples` toggle and its companion 
options (CSV filename, number of examples) appear active in the UI 
regardless of which prompt template is in use. But ICL examples only reach 
the model if the prompt template references `{{ response_examples }}`. The 
`DEFAULT_PROMPT_BASE_LEGACY` template (which all Home-* fine-tune presets 
default to) doesn't reference that variable, so enabling the ICL toggle 
under those presets has no observable effect — examples are loaded into 
memory and then silently discarded.

## How this was discovered

Empirically traced during testing on Home-3B-v3 Q8_0:

- Flipping `CONF_USE_IN_CONTEXT_LEARNING_EXAMPLES` between `True` and 
  `False` while keeping `CONF_PROMPT` at its preset default (BASE_LEGACY) 
  produced no measurable change in wire-captured system prompts.
- Inspecting the render path in `_generate_system_prompt` confirmed that 
  `render_variables["response_examples"]` gets populated (or doesn't) 
  based on the toggle and the `llm_api`/`in_context_examples` gates, but 
  the rendered output is unchanged because the template doesn't reference 
  the variable.
- Reviewing `const.py` confirmed that the BASE_LEGACY template doesn't 
  include `{% for item in response_examples %}…{% endfor %}` from 
  `ICL_EXTRAS`, while the non-legacy `DEFAULT_PROMPT = DEFAULT_PROMPT_BASE 
  + ICL_EXTRAS` does.

## Why it's user-facing

All current Home-* presets (`home-llama-3.2`, `home-3b-v3` through `-v1`, 
`home-1b-v3` through `-v1`, `stablehome`, `tinyhome`) ship with 
`CONF_USE_IN_CONTEXT_LEARNING_EXAMPLES: False` as a per-preset override, 
so a fresh install of those models doesn't trigger the surprise. The 
inertness manifests when:

1. A user picks a Home-* preset and **explicitly enables** the ICL toggle 
   in options, expecting it to take effect, or
2. A user customizes a non-Home preset's prompt template (which has ICL 
   on by global default) by replacing the body with BASE_LEGACY-style 
   content but leaves the ICL toggle on.

Both cases produce silent inertness — no log message, no UI hint. The 
toggle is just inactive.

## Fix (two parts)

### Part A — Runtime warning in `entity.py`

Adds a diagnostic `_LOGGER.warning` in `_generate_system_prompt` that 
fires when the trio of preconditions is met (`in_context_examples` 
loaded, `llm_api` exposed, ICL examples generated) but the active 
`prompt_template` doesn't contain the literal string `response_examples`. 
The warning surfaces the silent inertness in the HA logs where users can 
diagnose it.

Implementation: 7 lines, substring check, no behavior change beyond the 
log line. Matches the existing per-render warning pattern at 
`entity.py:477,490`.

### Part B — Documentation in `Model Prompting.md`

Adds a new subsection `### When {{ response_examples }} is rendered` 
between the existing CSV-file paragraph and the "Home Model Persona" 
heading. Explains:

1. The prompt-template-must-contain-marker prerequisite.
2. The fact that BASE_LEGACY-using Home-* presets don't include the 
   marker by default.
3. The two paths forward (customize template, or switch preset).
4. A pointer to the new WARNING log line.

## Out of scope

- **Making BASE_LEGACY honor ICL automatically** — would require 
  appending `ICL_EXTRAS` to the BASE_LEGACY template when the toggle is 
  on. This is a runtime modification to a template that Home-* models 
  were specifically trained against; without per-model empirical 
  validation it risks regressing inference quality on the recommended 
  model path. Belongs in a separate issue with model-side evidence 
  requirements.

- **Config-flow gating** (hide the ICL fields when BASE_LEGACY is 
  selected, or block submit with a validator) — acon96 noted in #118 
  that "dynamic settings forms just aren't a thing without going and 
  writing a React component myself." A post-submit validator could be a 
  follow-up if the warning + docs don't reduce confusion enough.

## Diff note

GitHub's PR view shows an extra deletion + addition in `def supported_languages` 
due to web-editor trailing-whitespace stripping on an adjacent line. Verified 
whitespace-only via `?w=1`. The substantive entity.py change is the 7-line 
warning block in `_generate_system_prompt`.

## Related

- #118 — the existing open ICL issue (different concern, but acon96's 
  comment there about dynamic-form limitations informs why this PR uses 
  a runtime warning rather than config-flow gating).